### PR TITLE
fix application/octet-stream request body content

### DIFF
--- a/src/main/java/com/xiaoleilu/loServer/handler/Request.java
+++ b/src/main/java/com/xiaoleilu/loServer/handler/Request.java
@@ -79,7 +79,7 @@ public class Request {
 
 		// request URI parameters
 		this.putParams(new QueryStringDecoder(uri));
-		if(nettyRequest.method() != HttpMethod.GET){
+		if(nettyRequest.method() != HttpMethod.GET && !"application/octet-stream".equals(nettyRequest.headers().get("Content-Type"))){
 			HttpPostRequestDecoder decoder = null;
 			try {
 				decoder = new HttpPostRequestDecoder(HTTP_DATA_FACTORY, nettyRequest);


### PR DESCRIPTION
当请求body为```application/octet-stream```时，会导致crash，且```application/octet-stream```时，body不包含其他参数。